### PR TITLE
Logging permissions error

### DIFF
--- a/qrcodescanner/src/main/java/com/blikoon/qrcodescanner/decode/DecodeManager.java
+++ b/qrcodescanner/src/main/java/com/blikoon/qrcodescanner/decode/DecodeManager.java
@@ -12,6 +12,8 @@ import com.blikoon.qrcodescanner.R;
 public class DecodeManager {
 
     public void showPermissionDeniedDialog(Context context) {
+        Log.e("DecodeManager", "Permissions not granted");
+        
         new AlertDialog.Builder(context).setTitle(R.string.qr_code_notification)
                 .setMessage(R.string.qr_code_camera_not_open)
                 .setPositiveButton(R.string.qr_code_positive_button_know, new DialogInterface.OnClickListener() {


### PR DESCRIPTION
Message "Could not open camera" does not give much information to developers