### PR TITLE
External permission

### DIFF
--- a/qrcodescanner/src/main/java/com/blikoon/qrcodescanner/decode/DecodeManager.java
+++ b/qrcodescanner/src/main/java/com/blikoon/qrcodescanner/decode/DecodeManager.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.util.Log;
 
 import com.blikoon.qrcodescanner.R;
 


### PR DESCRIPTION
Newer (>API16) android versions need to have explicit read external storage permission.
This will be requested if user click on top right "picture".